### PR TITLE
Round up the requested number of bytes to vmSbrk to at least maintain double float alignment.

### DIFF
--- a/Source/Runtime/Memory.cpp
+++ b/Source/Runtime/Memory.cpp
@@ -41,6 +41,8 @@ namespace Runtime
 
 	uint32 vmSbrk(int32 numBytes)
 	{
+		// Round up to an alignment boundary.
+		numBytes = (numBytes + 7) & ~7;
 		const uint32 existingNumBytes = numAllocatedBytes;
 		if(numBytes > 0)
 		{


### PR DESCRIPTION
Some code assumes these are aligned, and this helps maintain alignment.