### PR TITLE
Implement Emscripten _memcpy_big.

### DIFF
--- a/Source/Runtime/EmscriptenIntrinsics.cpp
+++ b/Source/Runtime/EmscriptenIntrinsics.cpp
@@ -165,7 +165,11 @@ namespace Runtime
 	DEFINE_INTRINSIC_FUNCTION4(emscripten,_catgets,I32,I32,catd,I32,set_id,I32,msg_id,I32,s) { return s; }
 	DEFINE_INTRINSIC_FUNCTION1(emscripten,_catclose,I32,I32,a) { return 0; }
 
-	DEFINE_INTRINSIC_FUNCTION3(emscripten,_emscripten_memcpy_big,I32,I32,a,I32,b,I32,c) { throw "_emscripten_memcpy_big"; }
+	DEFINE_INTRINSIC_FUNCTION3(emscripten,_emscripten_memcpy_big,I32,I32,a,I32,b,I32,c)
+	{
+	  memcpy(&instanceMemoryRef<uint32>(a),&instanceMemoryRef<uint32>(b),uint32(c));
+	  return a;
+	}
 
 	enum class ioStreamVMHandle
 	{

--- a/Source/Runtime/EmscriptenIntrinsics.cpp
+++ b/Source/Runtime/EmscriptenIntrinsics.cpp
@@ -167,8 +167,11 @@ namespace Runtime
 
 	DEFINE_INTRINSIC_FUNCTION3(emscripten,_emscripten_memcpy_big,I32,I32,a,I32,b,I32,c)
 	{
-	  memcpy(&instanceMemoryRef<uint32>(a),&instanceMemoryRef<uint32>(b),uint32(c));
-	  return a;
+		if (uint64(a) + uint64(c) >= instanceAddressSpaceMaxBytes &&
+		    uint64(b) + uint64(c) >= instanceAddressSpaceMaxBytes)
+			throw "_emscripten_memcpy_big";
+		memcpy(&instanceMemoryRef<uint32>(a),&instanceMemoryRef<uint32>(b),uint32(c));
+		return a;
 	}
 
 	enum class ioStreamVMHandle


### PR DESCRIPTION
Not much thought has been given to error handling and safety, but given that the arguments are 32 bit and the VM 64 bit many issues might be caught by the VM reserve. For a 32 bit WAVM it will probably be necessary to do some bounds checking here. This is intended to support running trusted code such as benchmarks for now. What do you think?