### PR TITLE
On Linux also check dlsym when resolving a symbol address.

### DIFF
--- a/Source/Runtime/LLVMJIT.cpp
+++ b/Source/Runtime/LLVMJIT.cpp
@@ -1,5 +1,9 @@
 #include "LLVMJIT.h"
 
+#if defined(__linux__)
+#include <dlfcn.h>
+#endif
+
 namespace LLVMJIT
 {
 	// Functor that receives notifications when an object produced by the JIT is loaded.
@@ -59,6 +63,14 @@ namespace LLVMJIT
 		if(intrinsicFunction) { return intrinsicFunction->value; }
 		else
 		{
+#if defined(__linux__)
+			void *library = dlopen(NULL, RTLD_NOW);
+			void *addr = dlsym(library, name.c_str());
+			dlclose(library);
+			if (addr)
+				return addr;
+#endif
+
 			std::cerr << "getSymbolAddress: " << name << " not found" << std::endl;
 			return nullptr;
 		}


### PR DESCRIPTION
This was need on the ARM which called some support functions, for example to do unsigned division.