### PR TITLE
Improve error message when initial memory size > maximum

### DIFF
--- a/Source/WebAssembly/WebAssemblyTextParse.cpp
+++ b/Source/WebAssembly/WebAssemblyTextParse.cpp
@@ -1367,7 +1367,7 @@ namespace WebAssemblyText
 						if(maxNumPages > (1ll<<32))
 							{ recordError<ErrorRecord>(outErrors,childNodeIt,"maximum memory size must be <=2^32 bytes"); continue; }
 						if(initialNumPages > maxNumPages)
-							{ recordError<ErrorRecord>(outErrors,childNodeIt,"initial memory size must be <= maximum memory size"); continue; }
+							{ recordError<ErrorRecord>(outErrors,childNodeIt,std::string("initial memory size '") + std::to_string(initialNumPages) + "' must be <= maximum specified memory size '" + std::to_string(maxNumPages) + "'"); continue; }
 						module->initialNumPagesMemory = (uint64) initialNumPages;
 						module->maxNumPagesMemory = (uint64) maxNumPages;
 				


### PR DESCRIPTION
Had a bug in my wast and it had  (memory 1 0 (segment ... and the error message was a the following

(5:5): initial memory size must be <= maximum memory size (S-expression node is (segment...)

The patch changes it to the following:

(5:5): initial memory size '1' must be <= maximum specified memory size '0' (S-expression node is (segment...)


But more generally what is your thoughts on diagnostics?
- Should error messages include the values such as with this change?
- not sure if it is a bug or not, but should it output 'segment' or '0' for the S-expression?
- should recordError output the source or is describeSNode support to do that?
- should the file name be included?

Matching more of what clangs diagnostics you would end up with something like the following:

test.wast:5:5: error: initial memory size '1' must be <= maximum specified memory size '0'  (S-expression node is 0)
(memory 1 0
                  ^