### PR TITLE
Remove std::move that would prevent copy elision and cause build warnings with clang

### DIFF
--- a/Source/Core/SExpressions.cpp
+++ b/Source/Core/SExpressions.cpp
@@ -785,7 +785,7 @@ namespace SExp
 		bool hasMultiLineSubtree = false;
 		do
 		{
-			childStrings.emplace_back(std::move(printNode(node,symbolStrings,newline,hasMultiLineSubtree)));
+			childStrings.emplace_back(printNode(node,symbolStrings,newline,hasMultiLineSubtree));
 			node = node->nextSibling;
 		}
 		while(node);

--- a/Source/WebAssembly/WebAssemblyTextParse.cpp
+++ b/Source/WebAssembly/WebAssemblyTextParse.cpp
@@ -173,7 +173,7 @@ namespace WebAssemblyText
 			TypeId type;
 			if(!parseType(childNodeIt,type)) { recordError<ErrorRecord>(outErrors,childNodeIt,"expected type"); return 0; }
 			auto nameCopy = arena.copyToArena(name,strlen(name)+1);
-			outVariables.emplace_back(std::move(Variable({type,nameCopy})));
+			outVariables.emplace_back(Variable({type,nameCopy}));
 			return 1;
 		}
 		else
@@ -183,7 +183,7 @@ namespace WebAssemblyText
 			{
 				TypeId type;
 				if(!parseType(childNodeIt,type)) { recordError<ErrorRecord>(outErrors,childNodeIt,"expected type"); return numVariables; }
- 				outVariables.emplace_back(std::move(Variable({type,nullptr})));
+				outVariables.emplace_back(Variable({type,nullptr}));
 				++numVariables;
 			}
 			return numVariables;
@@ -893,11 +893,11 @@ namespace WebAssemblyText
 					else
 					{
 						// Failed to parse an expression.
-						auto error = as<Class>(recordError<Error>(outErrors,nodeIt,std::move(std::string("expected ")
+						auto error = as<Class>(recordError<Error>(outErrors,nodeIt,std::string("expected ")
 							+ getTypeName(type)
 							+ " expression for "
 							+ errorContext
-							)));
+							));
 						++nodeIt;
 						return error;
 					}


### PR DESCRIPTION
[-Werror,-Wpessimizing-move]