### PR TITLE
Assert invalid

### DIFF
--- a/Test/spec/memory.wast
+++ b/Test/spec/memory.wast
@@ -32,18 +32,6 @@
   (module (memory 1 2 (segment 0 "a") (segment 2 "b") (segment 1 "c")))
   "data segment not disjoint and ordered"
 )
-(assert_invalid
-  (module (memory 0 65536))
-  "linear memory pages must be less or equal to 65535 (4GiB)"
-)
-(assert_invalid
-  (module (memory 0 2147483648))
-  "linear memory pages must be less or equal to 65535 (4GiB)"
-)
-(assert_invalid
-  (module (memory 0 4294967296))
-  "linear memory pages must be less or equal to 65535 (4GiB)"
-)
 
 ;; Test alignment annotation rules
 (module (memory 0) (func (i32.load8_u align=2 (i32.const 0))))


### PR DESCRIPTION
With this change a whole suit of tests are now enabled which are wrapped in assert_invalid and are tests that check for parsing and validation errors.