### PR TITLE
Timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
+option(WAVM_TIMER_OUTPUT "controls printing the timings of some operations to stdout" OFF)
+if(WAVM_TIMER_OUTPUT)
+	add_definitions("-DWAVM_TIMER_OUTPUT=1")
+endif()
+
 add_subdirectory(Source/Core)
 add_subdirectory(Source/AST)
 add_subdirectory(Source/WebAssembly)

--- a/Source/Programs/CLI.h
+++ b/Source/Programs/CLI.h
@@ -33,7 +33,9 @@ inline bool loadTextFile(const char* filename,WebAssemblyText::File& outFile)
 	auto wastString = std::string((const char*)wastBytes.data(),wastBytes.size());
 	wastBytes.clear();
 
+	#if WAVM_TIMER_OUTPUT
 	Core::Timer loadTimer;
+	#endif
 	if(!WebAssemblyText::parse(wastString.c_str(),outFile))
 	{
 		// Build an index of newline offsets in the file.
@@ -55,7 +57,9 @@ inline bool loadTextFile(const char* filename,WebAssemblyText::File& outFile)
 		}
 		return false;
 	}
-	//std::cout << "Loaded in " << loadTimer.getMilliseconds() << "ms" << " (" << (wastString.size()/1024.0/1024.0 / loadTimer.getSeconds()) << " MB/s)" << std::endl;
+	#if WAVM_TIMER_OUTPUT
+	std::cout << "Loaded in " << loadTimer.getMilliseconds() << "ms" << " (" << (wastString.size()/1024.0/1024.0 / loadTimer.getSeconds()) << " MB/s)" << std::endl;
+	#endif
 	return true;
 }
 
@@ -82,7 +86,9 @@ inline AST::Module* loadBinaryModule(const char* wasmFilename,const char* memFil
 	if(!staticMemoryData.size()) { return nullptr; }
 
 	// Load the module from a binary WebAssembly file.
+	#if WAVM_TIMER_OUTPUT
 	Core::Timer loadTimer;
+	#endif
 	std::vector<AST::ErrorRecord*> errors;
 	AST::Module* module;
 	if(!WebAssemblyBinary::decode(wasmBytes.data(),wasmBytes.size(),staticMemoryData.data(),staticMemoryData.size(),module,errors))
@@ -91,7 +97,9 @@ inline AST::Module* loadBinaryModule(const char* wasmFilename,const char* memFil
 		for(auto error : errors) { std::cerr << wasmFilename << ":" << error->message.c_str() << std::endl; }
 		return nullptr;
 	}
-	//std::cout << "Loaded in " << loadTimer.getMilliseconds() << "ms" << " (" << (wasmBytes.size()/1024.0/1024.0 / loadTimer.getSeconds()) << " MB/s)" << std::endl;
+	#if WAVM_TIMER_OUTPUT
+	std::cout << "Loaded in " << loadTimer.getMilliseconds() << "ms" << " (" << (wasmBytes.size()/1024.0/1024.0 / loadTimer.getSeconds()) << " MB/s)" << std::endl;
+	#endif
 
 	return module;
 }

--- a/Source/Programs/Run.cpp
+++ b/Source/Programs/Run.cpp
@@ -40,7 +40,9 @@ int main(int argc,char** argv)
 
 	if(!Runtime::loadModule(module)) { return EXIT_FAILURE; }
 
+	#if WAVM_TIMER_OUTPUT
 	Core::Timer executionTime;
+	#endif
 	auto functionExport = module->exportNameToFunctionIndexMap.find(functionName);
 	if(functionExport != module->exportNameToFunctionIndexMap.end())
 	{
@@ -85,9 +87,10 @@ int main(int argc,char** argv)
 		std::cerr << "Module does not export '" << functionName << "'" << std::endl;
 		return EXIT_FAILURE;
 	}
+	#if WAVM_TIMER_OUTPUT
 	executionTime.stop();
-
 	std::cout << "Execution time: " << executionTime.getMilliseconds() << "ms" << std::endl;
+	#endif
 
 	return EXIT_SUCCESS;
 }

--- a/Source/Runtime/LLVMEmitIR.cpp
+++ b/Source/Runtime/LLVMEmitIR.cpp
@@ -846,7 +846,9 @@ namespace LLVMJIT
 	llvm::Module* emitModule(const Module* astModule)
 	{
 		// Create a JIT module.
+		#if WAVM_TIMER_OUTPUT
 		Core::Timer emitTimer;
+		#endif
 		ModuleIR moduleIR;
 
 		// Create literals for the virtual memory base and mask.
@@ -969,7 +971,9 @@ namespace LLVMJIT
 			irBuilder.CreateRetVoid();
 		}
 
+		#if WAVM_TIMER_OUTPUT
 		std::cout << "Emitted LLVM IR for module in " << emitTimer.getMilliseconds() << "ms" << std::endl;
+		#endif
 
 		return moduleIR.llvmModule;
 	}

--- a/Source/Runtime/LLVMJIT.cpp
+++ b/Source/Runtime/LLVMJIT.cpp
@@ -267,7 +267,9 @@ namespace LLVMJIT
 		#endif
 
 		// Run some optimization on the module's functions.
+		#if WAVM_TIMER_OUTPUT
 		Core::Timer optimizationTimer;
+		#endif
 
 		auto fpm = new llvm::legacy::FunctionPassManager(llvmModule);
 		fpm->add(llvm::createPromoteMemoryToRegisterPass());
@@ -280,14 +282,18 @@ namespace LLVMJIT
 		{ fpm->run(*functionIt); }
 		delete fpm;
 
+		#if WAVM_TIMER_OUTPUT
 		std::cout << "Optimized LLVM code in " << optimizationTimer.getMilliseconds() << "ms" << std::endl;
-		
+		#endif
+
 		#ifdef _DEBUG
 			printModule(llvmModule,"llvmOptimizedDump.ll");
 		#endif
 
 		// Pass the module to the JIT compiler.
+		#if WAVM_TIMER_OUTPUT
 		Core::Timer machineCodeTimer;
+		#endif
 		std::vector<llvm::Module*> moduleSet;
 		moduleSet.push_back(llvmModule);
 
@@ -299,7 +305,9 @@ namespace LLVMJIT
 
 		// Compile the module.
 		jitModule->handle = jitModule->compileLayer->addModuleSet(moduleSet,llvm::make_unique<SectionMemoryManager>(),&IntrinsicResolver::singleton);
+		#if WAVM_TIMER_OUTPUT
 		std::cout << "Generated machine code in " << machineCodeTimer.getMilliseconds() << "ms" << std::endl;
+		#endif
 		
 		return true;
 	}


### PR DESCRIPTION
Wasn't sure what the plans were with the timers that were in the code.  Some are disabled, some are not.   I took them all and wrapped them in an environment variable WAVM_TIMER so they could be turned on at a later time.

If they were just for profiling purposes and rarely used I could make two commits, the first enables them all, the second deletes them all so in the future anyone can just revert the second commit to be able to profile.

But if on the other hand they are just left over from initial work and future profiling would be done with tools like Valgrind I can change this pull request to just remove them.