### PR TITLE
Improve windows allocateVirtualPages error reporting to match posix implementation

### DIFF
--- a/Source/Core/Windows.cpp
+++ b/Source/Core/Windows.cpp
@@ -64,7 +64,14 @@ namespace Platform
 
 	uint8* allocateVirtualPages(size_t numPages)
 	{
-		return (uint8*)VirtualAlloc(nullptr,numPages << getPageSizeLog2(),MEM_RESERVE,PAGE_NOACCESS);
+		size_t numBytes = numPages << getPageSizeLog2();
+		auto result = VirtualAlloc(nullptr,numBytes,MEM_RESERVE,PAGE_NOACCESS);
+		if(result == NULL)
+		{
+                        std::cerr << "VirtualAlloc(" << numBytes/1024 << "KB) failed: GetLastError=" << GetLastError() << std::endl;
+                        return nullptr;
+		}
+		return (uint8*)result;
 	}
 
 	bool commitVirtualPages(uint8* baseVirtualAddress,size_t numPages,MemoryAccess access)


### PR DESCRIPTION
Need to build/test this on windows, but noticed that the behavior of the two were different and while posix would output a helpful error windows fails silently.