### PR TITLE
Don't write an empty table

### DIFF
--- a/Source/WebAssembly/WebAssemblyTextPrint.cpp
+++ b/Source/WebAssembly/WebAssemblyTextPrint.cpp
@@ -541,10 +541,13 @@ namespace WebAssemblyText
 		}
 
 		// Print the module function table.
-		auto tableStream = createTaggedSubtree(Symbol::_table);
-		for(uintptr elementIndex = 0;elementIndex < module->functionTable.numFunctions;++elementIndex)
-		{ tableStream << getFunctionName(module->functionTable.functionIndices[elementIndex]); }
-		moduleStream << tableStream;
+		if (module->functionTable.numFunctions != 0)
+		{
+			auto tableStream = createTaggedSubtree(Symbol::_table);
+			for(uintptr elementIndex = 0;elementIndex < module->functionTable.numFunctions;++elementIndex)
+			{ tableStream << getFunctionName(module->functionTable.functionIndices[elementIndex]); }
+			moduleStream << tableStream;
+		}
 
 		// Print the module exports.
 		for(auto exportIt : module->exportNameToFunctionIndexMap)


### PR DESCRIPTION
Empty tables are invalid and cause an error when trying to load the wast