### PR TITLE
Prevent possible random access when accessing std::vector

### DIFF
--- a/Source/Programs/CLI.h
+++ b/Source/Programs/CLI.h
@@ -51,8 +51,8 @@ inline bool loadTextFile(const char* filename,WebAssemblyText::File& outFile)
 		for(auto error : outFile.errors)
 		{
 			std::cerr << filename << ":" << error->locus.describe() << ": " << error->message.c_str() << std::endl;
-			auto startLine = wastFileLineOffsets[error->locus.newlines];
-			auto endLine =  wastFileLineOffsets[error->locus.newlines+1];
+			auto startLine = wastFileLineOffsets.at(error->locus.newlines);
+			auto endLine =  wastFileLineOffsets.at(error->locus.newlines+1);
 			std::cerr << wastString.substr(startLine, endLine-startLine-1) << std::endl;
 			std::cerr << std::setw(error->locus.column(8)) << "^" << std::endl;
 		}


### PR DESCRIPTION
When reading a value out of std::vector switch to use at() rather than []
because it will do a bound check, preventing possible reading of memory not
set by the program.