### PR TITLE
Add --check option to wasm for verifying programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Usage: wavm [switches] [programfile] [--] [arguments]
   --text in.wast                Specify text program file (.wast)
   --binary in.wasm in.js.mem    Specify binary program file (.wasm) and memory file (.js.mem)
   -f|--function name            Specify function name to run in module rather than main
+  -c|--check                    Exit after checking that the program is valid
   --                            Stop parsing arguments
 
 PrintWAST -binary in.wasm in.js.mem out.wast

--- a/Source/Programs/wavm.cpp
+++ b/Source/Programs/wavm.cpp
@@ -21,6 +21,7 @@ void showHelp()
 	std::cerr << "  --text in.wast\t\tSpecify text program file (.wast)" << std::endl;
 	std::cerr << "  --binary in.wasm in.js.mem\tSpecify binary program file (.wasm) and memory file (.js.mem)" << std::endl;
 	std::cerr << "  -f|--function name\t\tSpecify function name to run in module rather than main" << std::endl;
+	std::cerr << "  -c|--check\t\t\tExit after checking that the program is valid" << std::endl;
 	std::cerr << "  --\t\t\t\tStop parsing arguments" << std::endl;
 }
 
@@ -31,6 +32,7 @@ int main(int argc,char** argv)
 	const char* binaryMemFile = 0;
 	const char* functionName = 0;
 
+	bool check = false;
 	auto args = argv;
 	while(*++args)
 	{
@@ -60,6 +62,10 @@ int main(int argc,char** argv)
 		{
 			if(!*++args) { showHelp(); return EXIT_FAILURE; }
 			functionName = *args;
+		}
+		else if(!strcmp(*args, "--check") || !strcmp(*args, "-c"))
+		{
+			check = true;
 		}
 		else if(!strcmp(*args, "--"))
 		{
@@ -93,8 +99,10 @@ int main(int argc,char** argv)
 		showHelp();
 		return EXIT_FAILURE;
 	}
-
 	if(!module) { return EXIT_FAILURE; }
+
+	if (check) { return EXIT_SUCCESS; }
+
 	if(!Runtime::init()) { return EXIT_FAILURE; }
 	if(!Runtime::loadModule(module)) { return EXIT_FAILURE; }
 


### PR DESCRIPTION
Adds a new command line option to the wasm program --check or -c
that exits the application after the program has been successfully
parsed, but without executing it.

Handy when using american fuzzy lop, but you don't want it to execute
any code, just test the parser.

Similar to ruby -c, perl -c, bash -n