### PR TITLE
Don't assume decimal parsing was successful.

### DIFF
--- a/Source/Core/SExpressions.cpp
+++ b/Source/Core/SExpressions.cpp
@@ -549,6 +549,11 @@ namespace SExp
 					// Use David Gay's strtod to parse a floating point number.
 					const char* f64End;
 					auto f64 = DavidGay::parseDecimalF64(firstNumberChar,const_cast<char**>(&f64End));
+					if (f64End == firstNumberChar)
+					{
+						state.advance();
+						return createError(startLocus,"Unable to parse floating point number");
+					}
 					state.advanceToPtr(f64End);
 
 					auto node = new(arena) Node(startLocus,NodeType::Float);


### PR DESCRIPTION
When parsing a decimal isn't successful the state was not
being advanced and so the code just looped, trying over
and over to parse the decimal.

Example test case:
(module (func $x (local $s f32) (set_local $s (f32.const .a))))