### PR TITLE
Guard against badly formed names

### DIFF
--- a/Source/Core/SExpressions.cpp
+++ b/Source/Core/SExpressions.cpp
@@ -634,11 +634,10 @@ namespace SExp
 
 			// Consume characters until a non-name character is reached.
 			const char* nameStart = state.next;
-			do
+			while(isNameCharacter(state.peek()))
 			{
 				state.advance(true);
 			}
-			while(isNameCharacter(state.peek()));
 
 			// Copy the name's characters to the result arena.
 			Memory::ArenaString nameString;


### PR DESCRIPTION
A program that contains only the character '$' will cause the parser to advance off the end of memory.