### PR TITLE
When populating a std::map use emplace() rather than [] assignment

### DIFF
--- a/Source/WebAssembly/WebAssemblyTextSymbols.cpp
+++ b/Source/WebAssembly/WebAssemblyTextSymbols.cpp
@@ -48,7 +48,7 @@ namespace WebAssemblyText
 		if(!isInitialized)
 		{
 			auto numSymbols = sizeof(wastSymbols) / sizeof(wastSymbols[0]);
-			for(uintptr symbolIndex = 0;symbolIndex < numSymbols;++symbolIndex) { symbolIndexMap[wastSymbols[symbolIndex]] = symbolIndex; }
+			for(uintptr symbolIndex = 0;symbolIndex < numSymbols;++symbolIndex) { symbolIndexMap.emplace(std::make_pair(wastSymbols[symbolIndex], symbolIndex)); }
 			isInitialized = true;
 		}
 		return symbolIndexMap;


### PR DESCRIPTION
[] builds an empty value and immediately discards it.